### PR TITLE
Removing dead pups from dictionaries so it wont throw a null reference in case of trying adding them to the game.

### DIFF
--- a/SpawnedPups.cs
+++ b/SpawnedPups.cs
@@ -13,4 +13,24 @@ public class SpawnedPups
     tammedPups.Clear();
     uniqueMarkers.Clear();
   }
+
+  public bool Remove(AbstractCreature creature)
+  {
+    if (unTammedPups.ContainsKey(creature))
+    {
+      unTammedPups.Remove(creature);
+      return true;
+    }
+    if (tammedPups.ContainsKey(creature))
+    {
+      tammedPups.Remove(creature);
+      return true;
+    }
+    return false;
+  }
+
+  public bool ContainsKey(AbstractCreature creature)
+  {
+    return unTammedPups.ContainsKey(creature) || tammedPups.ContainsKey(creature);
+  }
 }

--- a/WhereSlugpupMain.cs
+++ b/WhereSlugpupMain.cs
@@ -99,10 +99,11 @@ partial class WhereSlugpupMain : BaseUnityPlugin
     private void Hook_On_AbstractCreature_Die(On.AbstractCreature.orig_Die orig, AbstractCreature self)
     {
 
-        if (self.world.game.IsStorySession && SpawnedPups.unTammedPups.ContainsKey(self))
+        if (self.world.game.IsStorySession && SpawnedPups.ContainsKey(self))
         {
             var pupData = SpawnedPups.unTammedPups[self];
             pupData.FoundPupMarker.PupDied();
+            SpawnedPups.Remove(self);// remove from dictionary
         }
 
 


### PR DESCRIPTION
This changes are meant to try to solve the NullReferenceExceptions that are given, i believe i have missmanaged the dictionaries somehow and some of them are giving null references instead.
![code](https://github.com/user-attachments/assets/68f908b3-d4af-41c9-a5b3-7f6dd37841e7)

Like here when we try to get pairPupData.Key

I have not tested if it works yet but ill when i can.