### PR TITLE
Adding more null checkers to HUD.Map.Draw and RainWorldGame.Update

### DIFF
--- a/MovingIcons.cs
+++ b/MovingIcons.cs
@@ -12,7 +12,7 @@ partial class WhereSlugpupMain
   {
     if (whereSlugpupOptions.wantsEnhancedSlugpupAwareness.Value && self.fade > 0f)
     {
-      List<AbstractCreature> slugcats = [.. SpawnedPups.unTammedPups.Keys, .. SpawnedPups.tammedPups.Keys];
+      List<AbstractCreature?> slugcats = [.. SpawnedPups.unTammedPups.Keys, .. SpawnedPups.tammedPups.Keys];
 
       FieldInfo creatureSymbolsField = typeof(Map).GetField("creatureSymbols", BindingFlags.NonPublic | BindingFlags.Instance);
       List<CreatureSymbol> creatureSymbols = (List<CreatureSymbol>)creatureSymbolsField.GetValue(self);// needed to use reflection here to access creatureSymbols
@@ -25,9 +25,10 @@ partial class WhereSlugpupMain
         }
       }
 
-      foreach (AbstractCreature slugcat in slugcats)
+      foreach (AbstractCreature? slugcat in slugcats)
       {
-        CreateSlugpupSymbol(self, slugcat, creatureSymbols, timeStacker);
+        if (slugcat is not null)
+          CreateSlugpupSymbol(self, slugcat, creatureSymbols, timeStacker);
       }
       slugcats.Clear();
     }

--- a/SpawnedPups.cs
+++ b/SpawnedPups.cs
@@ -4,8 +4,8 @@ namespace WhereSlugpupMod;
 
 public class SpawnedPups
 {
-  public readonly Dictionary<AbstractCreature, SlugpupData> unTammedPups = [];
-  public readonly Dictionary<AbstractCreature, SlugpupData> tammedPups = [];
+  public readonly Dictionary<AbstractCreature?, SlugpupData> unTammedPups = [];
+  public readonly Dictionary<AbstractCreature?, SlugpupData> tammedPups = [];
   public readonly HashSet<int> uniqueMarkers = []; //hashset is better to guarantee theres no duplicates
   public void Clear()
   {

--- a/StaticIcons.cs
+++ b/StaticIcons.cs
@@ -14,7 +14,7 @@ partial class WhereSlugpupMain
       for (int i = 0; i < uniqueMarkers.Count; i++)
       {
         var pup = unTammedPups.First(pup => pup.Value.FoundPupMarker.room == uniqueMarkers.ElementAt(i));
-        if (!pup.Value.IsMarkedOnTheMap)
+        if (pup.Key is not null && !pup.Value.IsMarkedOnTheMap)
         {
           pup.Key.world.game.cameras[0].hud.map.mapObjects.Add(unTammedPups[pup.Key].FoundPupMarker);
           pup.Value.IsMarkedOnTheMap = true;

--- a/WhereSlugpupMain.cs
+++ b/WhereSlugpupMain.cs
@@ -103,9 +103,7 @@ partial class WhereSlugpupMain : BaseUnityPlugin
         {
             var pupData = SpawnedPups.unTammedPups[self];
             pupData.FoundPupMarker.PupDied();
-            SpawnedPups.Remove(self);// remove from dictionary
         }
-
 
         orig(self);
     }
@@ -146,12 +144,12 @@ partial class WhereSlugpupMain : BaseUnityPlugin
         {
             string text = "Many slugpups has spawned!";
             var sb = new StringBuilder(text); // more efficient with stringBuilder
-            foreach (var pup in SpawnedPups.unTammedPups.Select(pupPair => pupPair.Key).ToList())
+            foreach (var pup in SpawnedPups.unTammedPups.Select(pupPair => pupPair.Key).AsEnumerable().Where(pup => pup is not null))
             {
                 if (whereSlugpupOptions.wantsPupID.Value)
-                    _ = sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", pup.ID);
+                    _ = sb.AppendFormat(CultureInfo.InvariantCulture, " {0}", pup!.ID);
                 if (whereSlugpupOptions.wantsPupRoom.Value)
-                    _ = sb.AppendFormat(CultureInfo.InvariantCulture, " in {0}", pup.Room.name);
+                    _ = sb.AppendFormat(CultureInfo.InvariantCulture, " in {0}", pup!.Room.name);
             }
             text = sb.ToString();
             self.cameras[0].hud.textPrompt.AddMessage(text, 10, 450, false, true);

--- a/WhereSlugpupOptions.cs
+++ b/WhereSlugpupOptions.cs
@@ -34,13 +34,13 @@ class WhereSlugpupOptions : OptionInterface
         [
                 new OpLabel(0, 550, "Where Slugpup Options !", true),
                 new OpCheckBox(wantsPupID, 50, 500),
-                new OpLabel(80, 500, "Show the found pup's ID", false),
+                new OpLabel(80, 500, "Show the found pup's ID"),
                 new OpCheckBox(wantsPupRoom, 50, 450),
-                new OpLabel(80, 450, "Show the found pup's spawn shelter name", false),
+                new OpLabel(80, 450, "Show the found pup's spawn shelter name"),
                 new OpCheckBox(wantsPupMap, 50, 400),
-                new OpLabel(80, 400, "Show the found pup's spawn shelter on map", false),
-                new OpCheckBox(wantsPupMap, 50, 450),
-                new OpLabel(80, 450, "Enhanced capability of detecting pups in the neighbours rooms", true),
+                new OpLabel(80, 400, "Show the found pup's spawn shelter on map"),
+                new OpCheckBox(wantsEnhancedSlugpupAwareness, 50, 350),
+                new OpLabel(80, 350, "Enhanced capability of detecting pups in the neighbours rooms"),
         ];
 
         optionTab.AddItems(UIArrayElements);


### PR DESCRIPTION
Hey i believe with those changes the game will work fine, i think whats happening is the object is being settled to null somewhere in the game and when the mod tries to update the pup data thru Map.Draw and RWGame.Update it fails because its obviously null, so i have added new null checkers and updated the dictionaries types.